### PR TITLE
Improve title bar and add response copy button

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -111,6 +111,15 @@ input {
   transition: none;
 }
 
+/* Electron window dragging */
+.app-drag-region {
+  -webkit-app-region: drag;
+}
+
+.app-no-drag {
+  -webkit-app-region: no-drag;
+}
+
 /* Focus styles with Electric Yellow accent */
 *:focus-visible {
   outline: 2px solid rgb(var(--color-primary));

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -17,6 +17,15 @@ export default function Message({ message }: MessageProps) {
   // Start expanded if there's thinking content, collapse when final content arrives
   const hasContent = message.content && message.content.trim().length > 0;
   const [thinkingExpanded, setThinkingExpanded] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!message.content) return;
+
+    await navigator.clipboard.writeText(message.content);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
 
   // Auto-collapse when content arrives (but only once)
   const [hasCollapsed, setHasCollapsed] = useState(false);
@@ -103,12 +112,36 @@ export default function Message({ message }: MessageProps) {
         )}
 
         <div
-          className={`rounded-claude-md px-6 py-5 ${
+          className={`relative rounded-claude-md px-6 py-5 ${
             isUser
               ? 'bg-pure-white dark:bg-dark-gray text-pure-black dark:text-pure-white shadow-claude-sm border border-pure-black/10 dark:border-pure-white/10'
               : 'bg-pure-white/5 dark:bg-dark-gray/5 text-pure-black dark:text-pure-white shadow-claude-sm border border-pure-black/10 dark:border-pure-white/10'
           }`}
         >
+        {!isUser && hasContent && (
+          <button
+            onClick={handleCopy}
+            className="absolute right-3 top-3 flex items-center gap-1.5 rounded-claude-sm border border-pure-black/10 dark:border-pure-white/10 bg-pure-white/90 dark:bg-dark-gray/90 px-2.5 py-1.5 text-xs font-medium text-neutral-gray hover:text-theme-primary hover:bg-pure-white dark:hover:bg-dark-gray shadow-claude-sm transition-colors"
+            aria-label="Copy assistant response"
+            title="Copy response"
+          >
+            {copied ? (
+              <>
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                Copied
+              </>
+            ) : (
+              <>
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                Copy
+              </>
+            )}
+          </button>
+        )}
 
         {/* Display attached files */}
         {message.files && message.files.length > 0 && (
@@ -146,7 +179,7 @@ export default function Message({ message }: MessageProps) {
             {message.content}
           </p>
         ) : (
-          <div className="prose prose-sm max-w-none prose-p:leading-relaxed prose-pre:p-0 prose-pre:m-0 font-sans">
+          <div className="prose prose-sm max-w-none prose-p:leading-relaxed prose-pre:p-0 prose-pre:m-0 font-sans pr-16">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{

--- a/components/chat/ChatHeader.tsx
+++ b/components/chat/ChatHeader.tsx
@@ -19,27 +19,35 @@ export function ChatHeader({
   onNewChat,
 }: ChatHeaderProps) {
   return (
-    <header className="sticky top-0 z-30 bg-pure-white/95 dark:bg-dark-gray/95 backdrop-blur border-b border-pure-black/10 dark:border-pure-white/10 px-4 py-3 flex justify-between items-center">
-      <div className="flex items-center gap-3">
-        <button
-          onClick={onToggleSidebar}
-          className="text-neutral-gray dark:text-neutral-gray hover:text-theme-primary dark:hover:text-theme-primary p-2 rounded-claude-sm hover:bg-pure-black/5 dark:hover:bg-pure-white/5 transition-colors"
-          aria-label={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
-        >
-          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h7" />
-          </svg>
-        </button>
-        <ModelSelector selectedModel={selectedModel} onSelect={onSelectModel} />
-      </div>
+    <header className={`sticky top-0 z-30 bg-pure-white dark:bg-dark-gray ${
+      !sidebarOpen ? 'border-t border-pure-black/25 dark:border-pure-white/20' : ''
+    }`}>
+      {/* Draggable titlebar area — matches the sidebar titlebar */}
+      <div className="app-drag-region h-[58px]" aria-hidden="true" />
 
-      <div className="flex items-center gap-2">
-        <button
-          onClick={onNewChat}
-          className="px-4 py-2 bg-theme-primary hover:bg-theme-primary-hover text-theme-primary-text rounded-claude-sm transition-colors font-medium text-sm hidden sm:block shadow-claude-sm"
-        >
-          New Chat
-        </button>
+      {/* Header content — below the titlebar */}
+      <div className="app-drag-region flex justify-between items-center px-4 pb-3 border-b border-pure-black/25 dark:border-pure-white/20 shadow-[0_3px_12px_rgba(0,0,0,0.08)] dark:shadow-[0_3px_12px_rgba(0,0,0,0.3)]">
+        <div className="flex items-center gap-3 app-no-drag">
+          <button
+            onClick={onToggleSidebar}
+            className="app-no-drag text-neutral-gray dark:text-neutral-gray hover:text-theme-primary dark:hover:text-theme-primary p-2 rounded-claude-sm hover:bg-pure-black/5 dark:hover:bg-pure-white/5 transition-colors"
+            aria-label={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h7" />
+            </svg>
+          </button>
+          <ModelSelector selectedModel={selectedModel} onSelect={onSelectModel} />
+        </div>
+
+        <div className="flex items-center gap-2 app-no-drag">
+          <button
+            onClick={onNewChat}
+            className="app-no-drag px-4 py-2 bg-theme-primary hover:bg-theme-primary-hover text-theme-primary-text rounded-claude-sm transition-colors font-medium text-sm hidden sm:block shadow-claude-sm"
+          >
+            New Chat
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/components/chat/ChatMessageList.tsx
+++ b/components/chat/ChatMessageList.tsx
@@ -105,8 +105,8 @@ export function ChatMessageList({
       className="flex-1 overflow-y-auto relative [scrollbar-width:none] [-ms-overflow-style:'none'] [&::-webkit-scrollbar]:hidden"
       ref={containerRef}
       style={{
-        maskImage: 'linear-gradient(to bottom, black 0%, black calc(100% - 120px), transparent 100%)',
-        WebkitMaskImage: 'linear-gradient(to bottom, black 0%, black calc(100% - 120px), transparent 100%)',
+        maskImage: 'linear-gradient(to bottom, black 0%, black calc(100% - 25px), transparent 100%)',
+        WebkitMaskImage: 'linear-gradient(to bottom, black 0%, black calc(100% - 25px), transparent 100%)',
       }}
     >
       <div className="max-w-[900px] mx-auto min-h-full flex flex-col pb-[20px]">

--- a/components/chat/ChatShell.tsx
+++ b/components/chat/ChatShell.tsx
@@ -39,6 +39,7 @@ export function ChatShell() {
   useTheme(); // Initialize theme system
 
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarWidth, setSidebarWidth] = useState(288);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -46,11 +47,22 @@ export function ChatShell() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    const savedSidebarWidth = Number(localStorage.getItem('ai-nexus-sidebar-width'));
+    if (savedSidebarWidth) {
+      setSidebarWidth(Math.min(Math.max(savedSidebarWidth, 240), 420));
+    }
+
     if (window.innerWidth < 768) {
       setSidebarOpen(false);
     } else {
       setSidebarOpen(true);
     }
+  }, []);
+
+  const handleSidebarWidthChange = useCallback((width: number) => {
+    const nextWidth = Math.min(Math.max(width, 240), 420);
+    setSidebarWidth(nextWidth);
+    localStorage.setItem('ai-nexus-sidebar-width', String(nextWidth));
   }, []);
 
   useEffect(() => {
@@ -123,6 +135,8 @@ export function ChatShell() {
         onRenameConversation={handleRenameConversation}
         onConversationsUpdate={handleConversationsUpdate}
         isOpen={sidebarOpen}
+        width={sidebarWidth}
+        onWidthChange={handleSidebarWidthChange}
       />
 
       <div className="flex-1 flex flex-col overflow-hidden">

--- a/components/chat/ModelSelector.tsx
+++ b/components/chat/ModelSelector.tsx
@@ -78,10 +78,10 @@ export function ModelSelector({ selectedModel, onSelect }: ModelSelectorProps) {
   };
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative app-no-drag" ref={containerRef}>
       <button
         onClick={() => setIsOpen(prev => !prev)}
-        className="flex items-center gap-2 px-3 py-2 text-gray-900 dark:text-gray-100 hover:text-theme-primary rounded-claude-sm hover:bg-pampas/50 dark:hover:bg-dark-bg/50 focus:outline-none transition-colors font-sans cursor-pointer text-base"
+        className="app-no-drag flex items-center gap-2 px-3 py-2 text-gray-900 dark:text-gray-100 hover:text-theme-primary rounded-claude-sm hover:bg-pampas/50 dark:hover:bg-dark-bg/50 focus:outline-none transition-colors font-sans cursor-pointer text-base"
       >
         <span>{selectedModelName}</span>
         <svg

--- a/components/sidebar/SidebarHeader.tsx
+++ b/components/sidebar/SidebarHeader.tsx
@@ -8,6 +8,7 @@ interface SidebarHeaderProps {
   showSearch: boolean;
   searchQuery: string;
   onSearchChange: (value: string) => void;
+  sidebarOpen: boolean;
 }
 
 export function SidebarHeader({
@@ -16,16 +17,23 @@ export function SidebarHeader({
   showSearch,
   searchQuery,
   onSearchChange,
+  sidebarOpen,
 }: SidebarHeaderProps) {
   return (
-    <div className="p-4 border-b border-pure-black/10 dark:border-pure-white/10">
-      <div className="mb-4">
+    <div className="border-b-2 border-pure-black/15 dark:border-pure-white/20">
+      {/* Titlebar area — sits beside the macOS traffic light buttons */}
+      <div
+        className={`app-drag-region h-[58px] flex items-center pl-[76px] pr-3 ${
+          !sidebarOpen ? 'border-b border-pure-black/25 dark:border-pure-white/20' : ''
+        }`}
+      >
         <Image
           src="/logo-light.png"
           alt="AI Nexus"
           width={208}
           height={50}
           className="w-52 h-auto block dark:hidden"
+          priority
         />
         <Image
           src="/logo-dark.png"
@@ -33,52 +41,58 @@ export function SidebarHeader({
           width={208}
           height={50}
           className="w-52 h-auto hidden dark:block"
+          priority
         />
-        <p className="text-xs text-neutral-gray dark:text-cloudy-400 mt-2 font-medium">Universal AI Interface</p>
       </div>
 
-      <div className="space-y-2">
-        <button
-          onClick={onNewChat}
-          className="w-full px-4 py-2 bg-theme-primary hover:bg-theme-primary-hover text-theme-primary-text rounded-claude-sm transition-colors font-medium flex items-center justify-center gap-2 shadow-claude-sm"
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          New Chat
-        </button>
-        <button
-          onClick={onCreateProject}
-          className="w-full px-4 py-2 bg-pure-black/5 dark:bg-pure-white/5 hover:bg-pure-black/10 dark:hover:bg-pure-white/10 text-pure-black dark:text-pure-white rounded-claude-sm transition-colors font-medium shadow-claude-sm flex items-center justify-center gap-2"
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-          </svg>
-          New Project
-        </button>
-      </div>
-
-      {showSearch && (
-        <div className="mt-3">
-          <div className="relative">
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(event) => onSearchChange(event.target.value)}
-              placeholder="Search conversations..."
-              className="w-full px-3 py-2 pl-9 bg-white dark:bg-dark-gray border border-pure-black/10 dark:border-pure-white/10 rounded-claude-sm text-sm text-pure-black dark:text-pure-white placeholder:text-cloudy-500 dark:placeholder:text-cloudy-400 focus:outline-none focus:ring-2 focus:ring-theme-primary/50 focus:border-theme-primary"
-            />
-            <svg
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-cloudy-500 dark:text-cloudy-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-          </div>
+      <div className="p-3">
+        <div className="mb-4">
+          <p className="text-xs text-neutral-gray dark:text-cloudy-400 font-medium">Universal AI Interface</p>
         </div>
-      )}
+
+        <div className="space-y-2">
+          <button
+            onClick={onNewChat}
+            className="app-no-drag w-full px-4 py-2 bg-theme-primary hover:bg-theme-primary-hover text-theme-primary-text rounded-claude-sm transition-colors font-medium flex items-center justify-center gap-2 shadow-claude-sm"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            New Chat
+          </button>
+          <button
+            onClick={onCreateProject}
+            className="app-no-drag w-full px-4 py-2 bg-pure-black/5 dark:bg-pure-white/5 hover:bg-pure-black/10 dark:hover:bg-pure-white/10 text-pure-black dark:text-pure-white rounded-claude-sm transition-colors font-medium shadow-claude-sm flex items-center justify-center gap-2"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+            </svg>
+            New Project
+          </button>
+        </div>
+
+        {showSearch && (
+          <div className="mt-3">
+            <div className="relative">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(event) => onSearchChange(event.target.value)}
+                placeholder="Search conversations..."
+                className="app-no-drag w-full px-3 py-2 pl-9 bg-white dark:bg-dark-gray border border-pure-black/10 dark:border-pure-white/10 rounded-claude-sm text-sm text-pure-black dark:text-pure-white placeholder:text-cloudy-500 dark:placeholder:text-cloudy-400 focus:outline-none focus:ring-2 focus:ring-theme-primary/50 focus:border-theme-primary"
+              />
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-cloudy-500 dark:text-cloudy-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/sidebar/SidebarShell.tsx
+++ b/components/sidebar/SidebarShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } from 'react';
 import { Conversation, Project } from '@/types/chat';
 import { storage } from '@/lib/storage';
 import { SidebarHeader } from './SidebarHeader';
@@ -20,6 +20,8 @@ interface SidebarShellProps {
   onRenameConversation: (id: string, newTitle: string) => void;
   onConversationsUpdate?: () => void;
   isOpen: boolean;
+  width: number;
+  onWidthChange: (width: number) => void;
 }
 
 export function SidebarShell({
@@ -31,6 +33,8 @@ export function SidebarShell({
   onRenameConversation,
   onConversationsUpdate,
   isOpen,
+  width,
+  onWidthChange,
 }: SidebarShellProps) {
   const [projects, setProjects] = useState<Project[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -134,13 +138,59 @@ export function SidebarShell({
   const hasConversations = conversations.length > 0;
   const hasProjects = projects.length > 0;
 
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  const handleResizeStart = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    const el = sidebarRef.current;
+    if (!el) return;
+
+    // Disable CSS transition during drag so width updates instantly
+    el.style.transition = 'none';
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const nextWidth = Math.min(Math.max(moveEvent.clientX, 240), 420);
+      el.style.width = `${nextWidth}px`;
+    };
+
+    const handleMouseUp = () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      // Re-enable CSS transition
+      el.style.transition = '';
+      // Finalize width in React state
+      const finalWidth = Math.min(Math.max(el.offsetWidth, 240), 420);
+      onWidthChange(finalWidth);
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
   return (
     <aside
       className={`relative h-full flex flex-col flex-shrink-0 bg-pure-white dark:bg-dark-gray transition-[transform,width] duration-300 ease-in-out ${
-        isOpen ? 'w-72 translate-x-0 border-r border-pure-black/10 dark:border-pure-white/10 shadow-claude-md' : 'w-72 -translate-x-full md:w-0 md:translate-x-0 md:border-r-0 md:shadow-none'
+        isOpen ? 'translate-x-0 border-r border-pure-black/25 dark:border-pure-white/20 shadow-[4px_0_16px_rgba(0,0,0,0.08)] dark:shadow-[4px_0_16px_rgba(0,0,0,0.35)]' : '-translate-x-full md:w-0 md:translate-x-0 md:border-r-0 md:shadow-none'
       } font-sans overflow-hidden`}
+      ref={sidebarRef}
+      style={{ width: isOpen ? width : 0 }}
     >
+      {isOpen && (
+        <div
+          onMouseDown={handleResizeStart}
+          className="app-no-drag absolute right-0 top-0 z-40 h-full w-1 cursor-col-resize bg-transparent hover:bg-pure-black/20 dark:hover:bg-pure-white/25 transition-colors"
+          aria-label="Resize sidebar"
+          role="separator"
+        />
+      )}
+
       <SidebarHeader
+        sidebarOpen={isOpen}
         onNewChat={onNewChat}
         onCreateProject={handleCreateProject}
         showSearch={hasConversations}

--- a/electron/utils/nextServer.ts
+++ b/electron/utils/nextServer.ts
@@ -165,9 +165,10 @@ export async function startNextServer(): Promise<string> {
   initLogger();
 
   // Use different ports for dev vs production
-  // Dev: 3000 (matches yarn dev)
+  // Dev: 3000 by default, override with AI_NEXUS_DEV_PORT if needed
   // Production: 54321 (safe port, unlikely to conflict)
-  const PORT = app.isPackaged ? 54321 : 3000;
+  const DEV_PORT = Number(process.env.AI_NEXUS_DEV_PORT || 3000);
+  const PORT = app.isPackaged ? 54321 : DEV_PORT;
 
   // Use 127.0.0.1 (IPv4) instead of localhost to avoid IPv6 connection issues
   const serverUrl = app.isPackaged


### PR DESCRIPTION
## Summary
- Make the chat header/title bar solid instead of translucent
- Mark the header as an Electron drag region while keeping buttons interactive
- Add a copy button to assistant responses with temporary copied feedback

## Testing
- yarn lint
- yarn build